### PR TITLE
Update Hugo to 0.155.0

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,13 +3,14 @@
 version: "3"
 
 vars:
-  HUGO_VERSION: "0.149.0"
+  HUGO_VERSION: "0.155.0"
   HUGO_RELEASES: https://github.com/gohugoio/hugo/releases/download/
 
 tasks:
   install:hugo:
     status:
-      - test -f bin/hugo
+      - test -x bin/hugo
+      - ./bin/hugo version | grep -q "hugo v{{.HUGO_VERSION}}"
     vars:
       ARCH: '{{if eq OS "darwin"}}universal{{else}}{{ARCH}}{{end}}'
     cmds:


### PR DESCRIPTION
- Changed Taskfile to check Hugo version
- Updated Hugo to v0.155.0

Release notes: https://github.com/gohugoio/hugo/releases/tag/v0.155.0

The reason I want you to upgrade, is because this upgrades chroma to v2.22.0 https://github.com/gohugoio/hugo/commit/1a9133075c68d2d4e983d7dbd1da75cf03d38301 (release notes: https://github.com/alecthomas/chroma/releases/tag/v2.22.0) which has the first support for MoonBit :)

Before:

<img width="736" height="291" alt="image" src="https://github.com/user-attachments/assets/09b06922-dbe5-4180-b73a-9c8e9a837cff" />

After:

<img width="736" height="301" alt="image" src="https://github.com/user-attachments/assets/6cad70fe-c05a-4b12-90ed-bbf8198beab4" />

(yes I see that the `using @firefly` part has kind of invalid coloring, but that's because the `using` syntax is so new and not yet supported by the pygments syntax I pulled this from)